### PR TITLE
🤖 Fix: Upgrade Qodana action to v2024.3

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -9,12 +9,16 @@ on:
 jobs:
   qodana:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2023.2
+        uses: JetBrains/qodana-action@v2024.3
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
         with:


### PR DESCRIPTION
## Problem
The Qodana workflow has been failing with 100% failure rate. All 10 recent runs failed with:
```
client version 1.41 is too old. Minimum supported API version is 1.44
```

The `JetBrains/qodana-action@v2023.2` is incompatible with current GitHub Actions runners.

## Solution
- ⬆️ Upgrade `JetBrains/qodana-action` from v2023.2 to v2024.3
- ⬆️ Upgrade `actions/checkout` from v3 to v4  
- 🔐 Add required permissions for Qodana scan

## Testing
This should resolve the Docker API compatibility issue and restore the Qodana code quality checks.

---
*Automated fix by Garry (OpenClaw) - GitHub Actions Health Check*