### PR TITLE
chore: Upgrade to .NET 10

### DIFF
--- a/geometrix-api/Geometrix.AppHost/Geometrix.AppHost.csproj
+++ b/geometrix-api/Geometrix.AppHost/Geometrix.AppHost.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>

--- a/geometrix-api/Geometrix.Application/Geometrix.Application.csproj
+++ b/geometrix-api/Geometrix.Application/Geometrix.Application.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<NoWarn>$(NoWarn);CA1062;1591</NoWarn>
 		<Nullable>enable</Nullable>

--- a/geometrix-api/Geometrix.Domain/Geometrix.Domain.csproj
+++ b/geometrix-api/Geometrix.Domain/Geometrix.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<NoWarn>$(NoWarn);CA1062;1591</NoWarn>
 		<Nullable>enable</Nullable>

--- a/geometrix-api/Geometrix.Infrastructure/Geometrix.Infrastructure.csproj
+++ b/geometrix-api/Geometrix.Infrastructure/Geometrix.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<NoWarn>$(NoWarn);CA1062;1591</NoWarn>
 		<Nullable>enable</Nullable>

--- a/geometrix-api/Geometrix.ServiceDefaults/Geometrix.ServiceDefaults.csproj
+++ b/geometrix-api/Geometrix.ServiceDefaults/Geometrix.ServiceDefaults.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>

--- a/geometrix-api/Geometrix.WebApi/Geometrix.WebApi.csproj
+++ b/geometrix-api/Geometrix.WebApi/Geometrix.WebApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<NoWarn>$(NoWarn);CA1062;1591;CA1801;S1128;S1481;S1075</NoWarn>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/geometrix-api/global.json
+++ b/geometrix-api/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.311",
-    "rollForward": "feature",
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## 🚀 .NET 10 Migration

This PR upgrades Geometrix to .NET 10, the latest version.

## Changes

### SDK & Runtime
- ✅ **global.json** → SDK 10.0.100 (with latestFeature rollForward)
- ✅ **All projects** → TargetFramework net10.0

### Projects Updated (6 total)
- Geometrix.Domain
- Geometrix.Application
- Geometrix.Infrastructure
- Geometrix.ServiceDefaults
- Geometrix.WebApi
- Geometrix.AppHost

## Breaking Changes

⚠️ **Requires .NET 10 SDK** to build locally:
```bash
dotnet --version  # Should be 10.0.x
```

## Testing Required

- [ ] All projects build successfully
- [ ] API still functions correctly
- [ ] Aspire dashboard works (Aspire v13 should support .NET 10)
- [ ] No runtime breaking changes

## Migration Notes

### For Developers
Install .NET 10 SDK: https://dotnet.microsoft.com/download/dotnet/10.0

### For CI/CD
GitHub Actions should auto-detect .NET 10. If not, workflows may need:
```yaml
- uses: actions/setup-dotnet@v5
  with:
    dotnet-version: 10.0.x
```

## Benefits

- ✅ Latest .NET features and performance improvements
- ✅ Latest security patches
- ✅ Better compatibility with modern NuGet packages
- ✅ Improved C# 13 language features support

## Risks

⚠️ Some NuGet packages may not yet fully support .NET 10  
⚠️ Potential minor API behavior changes

## Deployment Impact

After merging:
1. Rebuild Docker image with .NET 10 runtime
2. Test on staging/dev first
3. Monitor for any runtime issues
4. Redeploy to production (geometrix.garry-ai.cloud)

---
🤖 Part of organization-wide .NET 10 migration  
Related: Upgrading all 121 C# repositories