### PR TITLE
fix: Downgrade Swashbuckle to 6.10.2 for .NET 10

### DIFF
--- a/geometrix-api/Geometrix.WebApi/Geometrix.WebApi.csproj
+++ b/geometrix-api/Geometrix.WebApi/Geometrix.WebApi.csproj
@@ -32,8 +32,7 @@
 	<ItemGroup>
 		<!-- Third party -->
 		<PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.3" />
-		<PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.10.2" />
 		<PackageReference Include="EPPlus.Core" Version="1.5.4" />
 		<!-- Decorator injection comparison https://greatrexpectations.com/2018/10/25/decorators-in-net-core-with-dependency-injection -->
 		<PackageReference Include="Scrutor" Version="7.0.0" />


### PR DESCRIPTION
Swashbuckle 10.x has breaking changes. Using stable 6.10.2 instead.