### PR TITLE
fix: Add root redirect to Swagger UI

### DIFF
--- a/geometrix-api/Geometrix.WebApi/Program.cs
+++ b/geometrix-api/Geometrix.WebApi/Program.cs
@@ -44,6 +44,9 @@ else
 
 var provider = app.Services.GetRequiredService<IApiVersionDescriptionProvider>();
 
+// Redirect root to Swagger
+app.MapGet("/", () => Results.Redirect("/swagger"));
+
 app
     .UseStaticFiles()
     .UseProxy(configuration)

--- a/geometrix-api/Geometrix.WebApi/key-d6b19929-2de6-4c85-a6fd-a7c89538f080.xml
+++ b/geometrix-api/Geometrix.WebApi/key-d6b19929-2de6-4c85-a6fd-a7c89538f080.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<key id="d6b19929-2de6-4c85-a6fd-a7c89538f080" version="1">
+  <creationDate>2026-02-16T10:04:36.7828005Z</creationDate>
+  <activationDate>2026-02-16T10:04:36.7828005Z</activationDate>
+  <expirationDate>2026-05-17T10:04:36.7828005Z</expirationDate>
+  <descriptor deserializerType="Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+    <descriptor>
+      <encryption algorithm="AES_256_CBC" />
+      <validation algorithm="HMACSHA256" />
+      <masterKey p4:requiresEncryption="true" xmlns:p4="http://schemas.asp.net/2015/03/dataProtection">
+        <!-- Warning: the key below is in an unencrypted form. -->
+        <value>BKPlWR7qy5t/AN/rjeQqbJED8k785lxIuzMgsmql7DESuwKCSK4XNkqviAlACFJo6mfxs+oogv6bJXS0tWZwZQ==</value>
+      </masterKey>
+    </descriptor>
+  </descriptor>
+</key>


### PR DESCRIPTION
## 🔧 UX Fix: Root URL Redirect

Makes Geometrix more user-friendly by redirecting the root URL to Swagger documentation.

### Problem
Currently, accessing `https://geometrix.garry-ai.cloud/` returns a 404 error because no route is configured for the root path.

### Solution
Added `app.MapGet("/", () => Results.Redirect("/swagger"));` to redirect users to the Swagger UI automatically.

### Impact
✅ Better UX - users immediately see the API documentation  
✅ No breaking changes - all existing routes still work  
✅ Swagger still accessible at `/swagger` directly

### Testing
- [x] Build succeeds locally
- [ ] CI validation (automated)
- [ ] Manual test after deployment

---
Part of Geometrix .NET 10 deployment improvements.